### PR TITLE
Changed login page to include Email

### DIFF
--- a/SHPE-UF-Mobile-Swift/SHPE-UF-Mobile-Swift/ui/pages/signIn/SignInView.swift
+++ b/SHPE-UF-Mobile-Swift/SHPE-UF-Mobile-Swift/ui/pages/signIn/SignInView.swift
@@ -89,7 +89,7 @@ struct SignInView: View
                 // Email Text
                 VStack(alignment: .leading)
                 {
-                    Text("Username")
+                    Text("Username or Email")
                       .font(Font.custom("Univers LT Std", size: 16))
                       .foregroundColor(Color("whiteText"))
                     


### PR DESCRIPTION
### Summary

This is a simple text addition to let users know that emails can be used along with username.
